### PR TITLE
Fix Buffer error when null

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,7 +8,7 @@ module.exports = function (params, options) {
         let contents  = file.contents.toString('utf8');
         let pattern   = new RegExp(`${pattern_start}((.|\\n)*?)${pattern_end}`);
         let extract   = pattern.exec(contents);
-        extract       = extract ? extract[1] : null;
+        extract       = extract ? extract[1] : '';
         file.contents = new Buffer(extract);
         return cb(null, file);
     });


### PR DESCRIPTION
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type null.

Please we need this asap